### PR TITLE
fix lz77 bug

### DIFF
--- a/include/compress.h
+++ b/include/compress.h
@@ -59,7 +59,7 @@ int huffman_uncompress(const unsigned char *compressed, unsigned char **original
 /// 类型长度
 #define     LZ77_TYPE_BITS        1
 /// 滑动窗口偏移量长度
-#define     LZ77_WINOFF_BITS     12
+#define     LZ77_WINOFF_BITS     13
 /// 短语标志长度
 #define     LZ77_BUFLEN_BITS      5
 /// 下一个匹配符号长度

--- a/source/lz77.c
+++ b/source/lz77.c
@@ -77,7 +77,7 @@ static int compare_win(const unsigned char *window,
 
 int lz77_compress(const unsigned char *original, unsigned char **compressed, int size)
 {
-  unsigned long   token;
+  unsigned int   token;
   unsigned char   window[LZ77_WINDOW_SIZE], buffer[LZ77_BUFFER_SIZE], *comp, *temp, next;
   int             offset, length, remaining, tbits, hsize, ipos, opos, tpos, i;
 
@@ -276,11 +276,11 @@ int lz77_uncompress(const unsigned char *compressed, unsigned char **original) {
 
       while (i < length && remaining > 0) {
 
-        orig[opos] = window[offset + i];
+        orig[opos] = window[offset + i - 1];
         opos++;
 
         /// 记录前向缓冲区中的符号直到更新入滑动窗口
-        buffer[i] = window[offset + i];
+        buffer[i] = window[offset + i - 1];
         i++;
 
         /// 更新生于的需要处理的符号数量


### PR DESCRIPTION
在lz77中，可以看到仍在使用32位操作系统的long表示32字节，导致部分同学clone测试失败，另一方面在窗口长度上也有部分错误，compare_win会返回匹配的下标加一，所以导致匹配后，offset实际范围为0-4096这个时候winoff_bit取13字节更为合适，在解压函数也应该做相应的修改